### PR TITLE
Add config option to control if torches can be made from fire pits

### DIFF
--- a/src/main/java/com/alcatrazescapee/notreepunching/ModConfig.java
+++ b/src/main/java/com/alcatrazescapee/notreepunching/ModConfig.java
@@ -52,6 +52,9 @@ public final class ModConfig
 
         @Config.Comment("If false, this will disable NTP world gen (surface rocks).")
         public boolean looseRocksGeneration = true;
+        
+        @Config.Comment("If false, this will disable the ability to get torches from fire pits.")
+        public boolean allowTorchesFromFirePits = true;
 
         @Config.Comment("Frequency of loose rocks in the world")
         @Config.RangeInt(min = 1, max = 1000)
@@ -162,7 +165,7 @@ public final class ModConfig
 
         @Config.Comment("Enable compatability features from Chisel (marble + limestone + basalt loose rocks)")
         public boolean enableChiselCompat = true;
-
+        
         //@Config.Comment("Enable compatibility features from Underground Biomes Constructs (UBC) (loose rocks)")
         //@Config.RequiresMcRestart
         //public boolean enableUBCCompat = true;

--- a/src/main/java/com/alcatrazescapee/notreepunching/common/blocks/BlockFirePit.java
+++ b/src/main/java/com/alcatrazescapee/notreepunching/common/blocks/BlockFirePit.java
@@ -185,9 +185,12 @@ public class BlockFirePit extends BlockTileCore
                     // Burn the end of a stick into a torch
                     if (!world.isRemote)
                     {
-                        CoreHelpers.giveItemToPlayer(world, player, new ItemStack(Blocks.TORCH, 2));
-                        player.setHeldItem(hand, CoreHelpers.consumeItem(player, stack, 1));
-                        world.playSound(null, player.getPosition(), SoundEvents.BLOCK_FIRE_EXTINGUISH, SoundCategory.PLAYERS, 0.5F, 1.5F);
+                        if (ModConfig.GENERAL.allowTorchesFromFirePits) 
+                        {
+                            CoreHelpers.giveItemToPlayer(world, player, new ItemStack(Blocks.TORCH, 2));
+                            player.setHeldItem(hand, CoreHelpers.consumeItem(player, stack, 1));
+                            world.playSound(null, player.getPosition(), SoundEvents.BLOCK_FIRE_EXTINGUISH, SoundCategory.PLAYERS, 0.5F, 1.5F);
+                        }
                     }
                     return true;
                 }


### PR DESCRIPTION
Adds a GeneralConfig option and a new allowTorchesFromFirePits boolean, as well as implementation to make the option function, to allow for the control of torches from fire pits.
Should resolve #98 and resolve #107, though the option for the creation of RealisticTorches's "Lit Torches" would be a better solution (that I would have implemented if I knew anything about the Forge API). 