### PR TITLE
Fix for ItemPhysics

### DIFF
--- a/Common/src/main/java/com/alcatrazescapee/notreepunching/util/Helpers.java
+++ b/Common/src/main/java/com/alcatrazescapee/notreepunching/util/Helpers.java
@@ -84,9 +84,9 @@ public final class Helpers
     {
         if (!stack.isEmpty() && !level.isClientSide)
         {
-            final ItemEntity entity = new ItemEntity(level, player.getX(), player.getY() + 0.5, player.getZ(), stack);
-            entity.setPickUpDelay(0);
-            level.addFreshEntity(entity);
+            if (!player.getInventory().add(stack)) {
+                player.drop(stack, false);
+            }
         }
     }
 


### PR DESCRIPTION
This line causes some weird interactions with the mod ItemPhysics By doing this you directly give the item to the players inventory if there is space if not, then the item is just dropped.